### PR TITLE
Export devicecheck library as API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## NEXT
 
+ * Export Apple App Attest Validation library as API
 
 ## 2.4.2
 * Update to latest WARDEN-roboto, bringing Google's PKI cert path validator to guard against cert path validations

--- a/warden/build.gradle.kts
+++ b/warden/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     }
     api(bouncycastle("bcpkix", "jdk18on"))
     api(datetime())
-    implementation("ch.veehait.devicecheck:devicecheck-appattest:0.9.6")
+    api("ch.veehait.devicecheck:devicecheck-appattest:0.9.6")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.14.2")
     implementation("net.swiftzer.semver:semver:1.2.0")
     implementation("org.slf4j:slf4j-api:1.7.36")


### PR DESCRIPTION
Otherwise clients can't access `ValidatedAttestation` from `AttestationResult.IOS.Verified.attestation`